### PR TITLE
Fixed pervasive multiprocessing errors.

### DIFF
--- a/config.py
+++ b/config.py
@@ -22,7 +22,7 @@ class DevConfig(object):
 
 	SESSION_LENGTH = 7
 
-	NUM_CORES = 1
+	NUM_CORES = 2
 
 class ProdConfig(object):
 	DEBUG = False

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -106,7 +106,6 @@ def word_freq(files, keywords):
         keywords = [keywords]
     # Remove duplicates and make all keywords lowercase.
     keywords = [keyword.lower() for keyword in set(keywords)]
-    to_process = len(files)
 
     word_freqs = get_pool().starmap(get_word_freq, zip(files, repeat(keywords)))
     # Currrently, discard any files that couldn't be found.
@@ -161,11 +160,10 @@ def top_bigrams_task(file_list_path):
     return_from_task(get_top_bigrams(file_list))
 
 def get_top_bigrams(files):
-    to_process = len(files)
     bigram_freqs = partition_map(get_bigrams, [x[::-1] for x in files])
     # Currently, discard any files that couldn't be found.
     bigram_freqs = [x for x in bigram_freqs if x is not None]
-    set_task_metadata("files_analyzed", len(bigram_freqs))
+    push_metadata_to_db("files_analyzed", force = True)
 
     # Merge dictionaries.
     years = [x[1] for x in files]

--- a/tasks/util.py
+++ b/tasks/util.py
@@ -196,7 +196,7 @@ def push_metadata_to_db(db_metadata_k, rq_metadata_k = "processed", step = 100, 
 def inc_task_processed(amt = 1):
     job = get_current_job()
     if job:
-        rq_obj_lock.acquire() # locks don't work. TODO
+        rq_obj_lock.acquire()
         job.refresh()
         job.meta['processed'] += amt
         job.save_meta()


### PR DESCRIPTION
When a task uses the get_pool() function (which is a wrapper for multiprocessing.get_pool), the slave threads are initialized using init_slave(). Little did I know, but during this initialization all members of the job class were being copied, including locks. So each thread had its own copy of the lock object, which of course offered no thread-safety.
This fundamental misunderstanding of Python didn't manifest itself until I tried creating pools with size > 1, for obvious reasons.
I found a minimally janky and moderately inelegant solution to my problem, relying somewhat on the second approach outlined in https://stackoverflow.com/questions/25557686/python-sharing-a-lock-between-processes/25558333. 