### PR TITLE
Tweaked task code.

### DIFF
--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -180,9 +180,10 @@ def get_top_bigrams(files):
     for year in global_freqs.keys():
         # Only return bigrams that make up more than .5% of all bigrams for that year.
         #freq_threshold = 0.005 * total_bigram_counts[year]
-        freq_threshold = 25
-        global_freqs[year] = {";".join(k):v for (k,v) in global_freqs[year].items() if v >= freq_threshold}
-    
+        #freq_threshold = 25
+        #global_freqs[year] = {";".join(k):v for (k,v) in global_freqs[year].items() if v >= freq_threshold}
+        global_freqs[year] = n_highest_entries(global_freqs[year], 50)
+
     return global_freqs
 
 def get_bigrams(files, year):
@@ -199,6 +200,7 @@ def get_bigrams(files, year):
         except FileNotFoundError as e:
             continue
         
+        file_bigrams = defaultdict(lambda: 0)
         file = list(map(lambda x: x.strip(), file.readlines()))
         for i in range(len(file) - 1):
             if file[i+1] in stopwords:
@@ -206,8 +208,15 @@ def get_bigrams(files, year):
                 continue
             if file[i] in stopwords:
                 continue
-            bigram = tuple(sorted((file[i], file[i+1])))
-            bigrams[bigram] += 1
+            bigram = tuple((file[i], file[i+1]))
+            file_bigrams[bigram] += 1
+
+        # Only take the top 50 bigrams for an individual file.
+        file_bigrams = n_highest_entries(file_bigrams, 50)
+        # Merge dictionaries.
+        for key, value in file_bigrams:
+            bigrams[key] += value
+
         file_length += len(files)
 
         inc_task_processed()

--- a/tasks/util.py
+++ b/tasks/util.py
@@ -71,7 +71,7 @@ def get_pool():
     lock_args = (rq_obj_lock, db_obj_lock)
     return multiprocessing.Pool(config["NUM_CORES"], initializer = init_slave, initargs=lock_args)
 
-def partition_map(map_func, items, size_func = lambda *a: 1, max_partition_size = 25):
+def partition_map(map_func, items, size_func = lambda *a: 1, max_partition_size = 100):
     items = [item + (size_func(item),) for item in items]
     partitions = partition(items, max_partition_size)
     mapped_values = get_pool().starmap(map_func, partitions)
@@ -252,3 +252,10 @@ def return_from_task(return_value):
     write_task_results(return_value)
 
 ### END TASK OUTPUT FILE CODE
+
+def n_highest_entries(d, n):
+    if isinstance(d, dict):
+        d = d.items()
+    elif not isinstance(d, list):
+        return None
+    return sorted(d, key = lambda x: x[1], reverse = True)[:n]


### PR DESCRIPTION
Though I wanted to get my current task code, I eventually realized that partition mapping was insufficient. The number of entries in a bigram frequency dictionary is proportional to the number of files in the partition, because individual files are not that similar. I changed the code to instead take only the top n (currently 50) bigrams for each file. I also only return the top 50 bigrams for each year at the end. This isn't ideal, because if the 51st bigram in each file is the same, that bigram will overall be very common but will not make it into the results. Perhaps I could experiment with more efficient ways of storing bigrams, though I think even this will not offset the fact that there are so many different bigrams.